### PR TITLE
Removed redefinition of undefined

### DIFF
--- a/ko.editables.js
+++ b/ko.editables.js
@@ -6,7 +6,7 @@
 // License: MIT (http://www.opensource.org/licenses/mit-license.php)
 
 /*
-Exports: 
+Exports:
 ko.extenders.editable: ko.observable().extend({editable: true|false});
 ko.editable: ko.editable(objectWithObservables, boolean autoInit);
 
@@ -31,7 +31,7 @@ Editable adds following methods into observables and objects:
 		factory(ko)
 	}
 
-}(function (ko, undefined) {
+}(function (ko) {
 	var deferredDependentObservable = function (readFunction) {
 		return ko.dependentObservable({ read: readFunction, deferEvaluation: true });
 	};


### PR DESCRIPTION
The factory function was defining `undefined` as an incoming argument, making later behavior comparing to `undefined`, well, undefined. This resulted in autoInit not being the default behavior for the `ko.editable(viewmodel)` function, plus other possible error behaviors.
