### PR TITLE
bower.json added to fix #18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bower_components
+node_modules
+.idea

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "romanych/ko.editables",
+  "main": "ko.editables.js",
+  "homepage": "https://romanych.github.io/ko.editables/",
+  "description": "This is plugin for KnockoutJS which allows to accept or rollback changes on observables or view models.",
+  "keywords": [
+    "ko",
+    "knockout",
+    "editable"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "knockout": "^3.4.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ko.editables",
+  "version": "0.9.0",
+  "description": "editable extender and ko.editable plugin for viewModels",
+  "main": "ko.editables.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/romanych/ko.editables"
+  },
+  "keywords": ["ko", "knockout"],
+  "author": "Roman Gomolko <rgomolko@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/romanych/ko.editables/issues"
+  },
+  "homepage": "https://github.com/romanych/ko.editables"
+}


### PR DESCRIPTION
Just noticed that there is no bower or npm package, and there is easy to fix #18 issue, so here is PR to solve it.

According to [this](https://github.com/bower/spec/blob/master/json.md#version) version is not required anymore, also I did not add authors, its up to you to add your self if needed.

BTW: How about adding package.json so later on package may be added to npm registry?
